### PR TITLE
chore(ci): use Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,15 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+deploy:
+  - provider: script
+    script: conform enforce
+    skip_cleanup: true
+    on:
+      branch: master
+  - provider: script
+    script: conform enforce
+    skip_cleanup: true
+    on:
+      tags: true


### PR DESCRIPTION
Travis checks out a specific commit which breaks branch detection by
detaching HEAD. This is a workaround