### PR TITLE
Allowing conform to be used in commit-msg git hooks

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -44,7 +44,7 @@ var buildCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		e, err := enforcer.New()
+		e, err := enforcer.New(cmd.Flags())
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/enforce.go
+++ b/cmd/enforce.go
@@ -33,7 +33,7 @@ var enforceCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		e, err := enforcer.New()
+		e, err := enforcer.New(cmd.Flags())
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -46,5 +46,6 @@ var enforceCmd = &cobra.Command{
 }
 
 func init() {
+	enforceCmd.Flags().String("commit-msg-file", "", "the path to the temporary commit message file")
 	RootCmd.AddCommand(enforceCmd)
 }

--- a/pkg/enforcer/enforcer.go
+++ b/pkg/enforcer/enforcer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/autonomy/conform/pkg/stage"
 	"github.com/autonomy/conform/pkg/task"
 	"github.com/mitchellh/mapstructure"
+	flag "github.com/spf13/pflag"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -41,7 +42,7 @@ var policyMap = map[string]policy.Policy{
 }
 
 // New loads the conform.yaml file and unmarshals it into a Conform struct.
-func New() (*Conform, error) {
+func New(flags *flag.FlagSet) (*Conform, error) {
 	configBytes, err := ioutil.ReadFile(".conform.yaml")
 	if err != nil {
 		return nil, err
@@ -51,6 +52,8 @@ func New() (*Conform, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.Metadata.Flags = flags
 
 	return c, nil
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/autonomy/conform/pkg/git"
+	flag "github.com/spf13/pflag"
 )
 
 // Metadata contains metadata.
@@ -14,6 +15,7 @@ type Metadata struct {
 	Git        *Git
 	Version    *Version
 	Variables  VariablesMap `yaml:"variables"`
+	Flags      *flag.FlagSet
 	Built      string
 }
 


### PR DESCRIPTION
feat: adding command line flag for commit msg

This allows someone to use `conform enforce` for commit-msg git hooks.