### PR TITLE
fix: excludeSuffixes wasn't skipping any files

### DIFF
--- a/internal/policy/license/license.go
+++ b/internal/policy/license/license.go
@@ -45,7 +45,7 @@ func (l *License) Compliance(options *policy.Options) (report policy.Report) {
 			// Skip excluded suffixes.
 			for _, suffix := range l.ExcludeSuffixes {
 				if strings.HasSuffix(info.Name(), suffix) {
-					continue
+					return nil
 				}
 			}
 			// Check files matching the included suffixes.
@@ -57,6 +57,7 @@ func (l *License) Compliance(options *policy.Options) (report policy.Report) {
 						return nil
 					}
 					ValidateLicenseHeader(&report, info.Name(), contents, []byte(l.Header))
+					return nil
 				}
 			}
 		}


### PR DESCRIPTION
`continue` was just running one more iteration `for` loop, being
effectively no-op.

While I'm at it, added another return to make sure file license
is validated only once even if matches multiple suffixes.